### PR TITLE
fix: allow editing of rate limit when SendEmailHook is enabled

### DIFF
--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -127,6 +127,9 @@ const RateLimits = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSuccess])
 
+  const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
+
+
   return (
     <div>
       <FormHeader
@@ -152,9 +155,9 @@ const RateLimits = () => {
                     handleReset={() => form.reset()}
                     disabled={!canUpdateConfig}
                     helper={
-                      !canUpdateConfig
-                        ? 'You need additional permissions to update authentication settings'
-                        : undefined
+                    !canUpdateConfig
+                    ? 'You need additional permissions to update authentication settings'
+                    : undefined
                     }
                   />
                 </div>
@@ -204,7 +207,7 @@ const RateLimits = () => {
                               </Button>
                             </AlertDescription_Shadcn_>
                           </Alert_Shadcn_>
-                        ) : !isSmtpEnabled(authConfig) ? (
+                        ) : !(isSmtpEnabled(authConfig) || hasAuthEmailHookEnabled) ? (
                           <Alert_Shadcn_>
                             <WarningIcon />
                             <AlertTitle_Shadcn_>
@@ -441,7 +444,7 @@ const RateLimits = () => {
         </Form_Shadcn_>
       )}
     </div>
-  )
+      )
 }
 
 export default RateLimits


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

For developers who only use the Send Email Hook and not the default or custom smtp