### PR TITLE
feat: improve timeouts for webhooks

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -92,7 +92,7 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
     function_type: isEdgeFunction(selectedHook?.function_args?.[0] ?? '')
       ? 'supabase_function'
       : 'http_request',
-    timeout_ms: Number(selectedHook?.function_args?.[4] ?? 1000),
+    timeout_ms: Number(selectedHook?.function_args?.[4] ?? 5000),
   }
 
   useEffect(() => {
@@ -165,8 +165,8 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
       }
     }
 
-    if (values.timeout_ms < 1000 || values.timeout_ms > 5000) {
-      errors['timeout_ms'] = 'Timeout should be between 1000ms and 5000ms'
+    if (values.timeout_ms < 1000 || values.timeout_ms > 10_000) {
+      errors['timeout_ms'] = 'Timeout should be between 1000ms and 10,000ms'
     }
 
     if (JSON.stringify(values) !== JSON.stringify(initialValues)) setIsEdited(true)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

We are getting quite a few timeouts in the edge runtime and this will ensure a better default. 

## What is the current behavior?

The default timeout is 1s, which results in a high number of 499 requests that aren't logged in the edge runtime. 

## What is the new behavior?

This increases the default to 5s and the max to 10s. 

## Additional context

Add any other context or screenshots.
